### PR TITLE
Report request and error

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ type Option struct {
 
 	// optional: see slog.HandlerOptions
 	AddSource   bool
-	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
+	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr // default: removeRequestAttr
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ type Option struct {
 	// Rollbar client
 	Client     *rollbar.Client
 	Timeout    time.Duration // default: 10s
-	SkipFrames *int // default: 2
+	SkipFrames *int          // default: 2
 
 	// optional: customize Rollbar event builder
 	Converter Converter

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ type Option struct {
 	Level     slog.Leveler
 
 	// Rollbar client
-	Client  *rollbar.Client
-	Timeout time.Duration // default: 10s
+	Client     *rollbar.Client
+	Timeout    time.Duration // default: 10s
+	SkipFrames *int // default: 2
 
 	// optional: customize Rollbar event builder
 	Converter Converter

--- a/handler.go
+++ b/handler.go
@@ -30,7 +30,7 @@ type Option struct {
 	// Rollbar client
 	Client     *rollbar.Client
 	Timeout    time.Duration // default: 10s
-	SkipFrames *int // default: 2
+	SkipFrames *int          // default: 2
 
 	// optional: customize Rollbar event builder
 	Converter Converter

--- a/handler.go
+++ b/handler.go
@@ -2,21 +2,35 @@ package slogrollbar
 
 import (
 	"context"
+	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/rollbar/rollbar-go"
 	slogcommon "github.com/samber/slog-common"
-
-	"log/slog"
 )
+
+type wrappedError struct {
+	msg string
+	error
+}
+
+func (w wrappedError) Unwrap() error {
+	return w.error
+}
+
+func (w wrappedError) Error() string {
+	return w.msg
+}
 
 type Option struct {
 	// log level (default: debug)
 	Level slog.Leveler
 
 	// Rollbar client
-	Client  *rollbar.Client
-	Timeout time.Duration // default: 10s
+	Client     *rollbar.Client
+	Timeout    time.Duration // default: 10s
+	SkipFrames *int
 
 	// optional: customize Rollbar event builder
 	Converter Converter
@@ -45,6 +59,15 @@ func (o Option) NewRollbarHandler() slog.Handler {
 		o.AttrFromContext = []func(ctx context.Context) []slog.Attr{}
 	}
 
+	if o.ReplaceAttr == nil {
+		o.ReplaceAttr = defaultReplaceAttr
+	}
+
+	if o.SkipFrames == nil {
+		o.SkipFrames = new(int)
+		*o.SkipFrames = 2
+	}
+
 	return &RollbarHandler{
 		option: o,
 		attrs:  []slog.Attr{},
@@ -66,19 +89,47 @@ func (h *RollbarHandler) Enabled(_ context.Context, level slog.Level) bool {
 
 func (h *RollbarHandler) Handle(ctx context.Context, record slog.Record) error {
 	fromContext := slogcommon.ContextExtractor(ctx, h.option.AttrFromContext)
-	extra := h.option.Converter(h.option.AddSource, h.option.ReplaceAttr, append(h.attrs, fromContext...), h.groups, &record)
+	extra := h.option.Converter(h.option.AddSource, h.option.ReplaceAttr,
+		append(h.attrs, fromContext...), h.groups, &record)
 	level := LogLevels[record.Level]
 
 	ctx, cancel := context.WithTimeout(context.Background(), h.option.Timeout)
 	defer cancel()
 
-	// if level == rollbar.ERR || level == rollbar.CRIT {
-	// 	skip := framesToSkip(2)
-	// 	h.option.Client.ErrorWithStackSkipWithExtrasAndContext(ctx, rollbar.ERR, err, skip, extra)
-	//  return nil
-	// }
+	// extract error and request from slog.Record
+	var r *http.Request
+	var err error
 
-	h.option.Client.MessageWithExtrasAndContext(ctx, level, record.Message, extra)
+	record.Attrs(func(a slog.Attr) bool {
+		if err != nil && r != nil {
+			return false
+		}
+
+		switch v := a.Value.Any().(type) {
+		case *http.Request:
+			// Pass the request to rollbar for additinoal context
+			r = v
+		case error:
+			// Keep the original message, but report as an error to Rollbar
+			// This enables stack tracing if the error has it.
+			err = wrappedError{msg: record.Message, error: v}
+		}
+		return true
+	})
+
+	if err != nil {
+		if r == nil {
+			h.option.Client.ErrorWithStackSkipWithExtrasAndContext(ctx, level, err, *h.option.SkipFrames, extra)
+		} else {
+			h.option.Client.RequestErrorWithStackSkipWithExtrasAndContext(ctx, level, r, err, *h.option.SkipFrames, extra)
+		}
+	} else {
+		if r == nil {
+			h.option.Client.MessageWithExtrasAndContext(ctx, level, record.Message, extra)
+		} else {
+			h.option.Client.RequestMessageWithExtrasAndContext(ctx, level, r, record.Message, extra)
+		}
+	}
 
 	return nil
 }
@@ -102,4 +153,17 @@ func (h *RollbarHandler) WithGroup(name string) slog.Handler {
 		attrs:  h.attrs,
 		groups: append(h.groups, name),
 	}
+}
+
+func defaultReplaceAttr(groups []string, a slog.Attr) slog.Attr {
+	// Leave group untouched
+	if len(groups) > 1 {
+		return a
+	}
+
+	if _, ok := a.Value.Any().(*http.Request); ok {
+		return slog.Attr{}
+	}
+
+	return a
 }

--- a/handler.go
+++ b/handler.go
@@ -161,6 +161,7 @@ func defaultReplaceAttr(groups []string, a slog.Attr) slog.Attr {
 		return a
 	}
 
+	// rollbar does not know how send http.Request objects
 	if _, ok := a.Value.Any().(*http.Request); ok {
 		return slog.Attr{}
 	}

--- a/handler.go
+++ b/handler.go
@@ -39,7 +39,7 @@ type Option struct {
 
 	// optional: see slog.HandlerOptions
 	AddSource   bool
-	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
+	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr // default: removeRequestAttr
 }
 
 func (o Option) NewRollbarHandler() slog.Handler {
@@ -60,7 +60,7 @@ func (o Option) NewRollbarHandler() slog.Handler {
 	}
 
 	if o.ReplaceAttr == nil {
-		o.ReplaceAttr = defaultReplaceAttr
+		o.ReplaceAttr = removeRequestAttr
 	}
 
 	if o.SkipFrames == nil {
@@ -155,7 +155,7 @@ func (h *RollbarHandler) WithGroup(name string) slog.Handler {
 	}
 }
 
-func defaultReplaceAttr(groups []string, a slog.Attr) slog.Attr {
+func removeRequestAttr(groups []string, a slog.Attr) slog.Attr {
 	// Leave group untouched
 	if len(groups) > 1 {
 		return a

--- a/handler.go
+++ b/handler.go
@@ -30,7 +30,7 @@ type Option struct {
 	// Rollbar client
 	Client     *rollbar.Client
 	Timeout    time.Duration // default: 10s
-	SkipFrames *int
+	SkipFrames *int // default: 2
 
 	// optional: customize Rollbar event builder
 	Converter Converter


### PR DESCRIPTION
Rollbar knows how to report extra request data and extract information from errors if it is explicitly told to do so.

This PR takes inspiration from the official rollbar-go client and its [Log](https://github.com/rollbar/rollbar-go/blob/ed38c7c74ef6a29c24f275e1f451d65a86c245f1/rollbar.go#L447) function to do so.

Changes in this PR:

- Implement a default `ReplaceAttr` to remove `*http.Request` attributes (as rollbar breaks if they are passed to it)
- Extract `*http.Request` and `error` objects from `slog.Record`
- Dispatch the correct reporter method following the same logic as the official [rollbar-go](https://github.com/rollbar/rollbar-go/blob/ed38c7c74ef6a29c24f275e1f451d65a86c245f1/rollbar.go#L447) client