### PR TITLE
fix: check error return value of client.Close in example

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/rollbar/rollbar-go"
@@ -18,7 +19,11 @@ func main() {
 	project := "samber/slog-rollbar/example"
 
 	client := rollbar.NewAsync(token, env, version, host, project)
-	defer client.Close()
+	defer func() {
+		if err := client.Close(); err != nil {
+			log.Printf("failed to close rollbar client: %v", err)
+		}
+	}()
 
 	logger := slog.New(slogrollbar.Option{Level: slog.LevelDebug, Client: client}.NewRollbarHandler())
 


### PR DESCRIPTION
Fixes `errcheck` lint failure on main.

The CI was failing because the return value of `client.Close()` was not being checked in `example/example.go`.

Changes:
- Handle the error return from `client.Close()` in a deferred closure